### PR TITLE
Enable onchain privacy

### DIFF
--- a/docker-compose_elk_privacy.yml
+++ b/docker-compose_elk_privacy.yml
@@ -111,6 +111,7 @@ services:
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion1:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -139,6 +140,7 @@ services:
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion2:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -167,6 +169,7 @@ services:
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion3:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:

--- a/docker-compose_elk_privacy_poa.yml
+++ b/docker-compose_elk_privacy_poa.yml
@@ -156,6 +156,7 @@ services:
       "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
       "--min-gas-price=0",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion1:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -187,6 +188,7 @@ services:
       "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
       "--min-gas-price=0",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion2:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -218,6 +220,7 @@ services:
       "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
       "--min-gas-price=0",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion3:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:

--- a/docker-compose_privacy.yml
+++ b/docker-compose_privacy.yml
@@ -92,6 +92,7 @@ services:
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion1:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -117,6 +118,7 @@ services:
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion2:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -142,6 +144,7 @@ services:
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion3:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:

--- a/docker-compose_privacy_poa.yml
+++ b/docker-compose_privacy_poa.yml
@@ -123,6 +123,7 @@ services:
       "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
       "--min-gas-price=0",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion1:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -150,6 +151,7 @@ services:
       "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
       "--min-gas-price=0",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion2:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:
@@ -177,6 +179,7 @@ services:
       "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
       "--min-gas-price=0",
       "--privacy-enabled",
+      "--privacy-onchain-groups-enabled",
       "--privacy-url=http://orion3:8888",
       "--privacy-public-key-file=/config/orion/orion.pub"]
     volumes:


### PR DESCRIPTION
Adds commandline parameters to enable on-chain privacy on the sample networks, allowing usage with web3js-eea examples, as well as on-chain privacy in general.