### PR TITLE
Added support for onchain privacy groups

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,7 @@ BESU_VERSION=latest
 SAMPLE_VERSION=$BESU_VERSION
 LOCK_FILE=.sampleNetworks.lock
 PERMISSIONING_ENABLED=false
+PRIVACY_ONCHAIN_GROUPS_ENABLED=false
 
 # path to use in containers for the mapping of the keys dir volume
 BESU_PUBLIC_KEY_DIRECTORY=/opt/besu/public-keys/

--- a/docker-compose_elk_privacy.yml
+++ b/docker-compose_elk_privacy.yml
@@ -53,7 +53,7 @@ services:
     environment:
       - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
       - LOG4J_CONFIGURATION_FILE=/config/log-config.xml
-    entrypoint: /opt/besu/bootnode_start.sh --config-file=/config/config.toml --network=dev --min-gas-price=0
+    entrypoint: /opt/besu/bootnode_start.sh --config-file=/config/config.toml --network=dev --min-gas-price=0 --privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -69,7 +69,8 @@ services:
       "--config-file=/config/config.toml",
       "--network=dev",
       "--min-gas-price=0",
-      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV" ]
+      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -90,7 +91,8 @@ services:
       "--network=dev",
       "--min-gas-price=0",
       "--miner-enabled=true",
-      "--miner-coinbase=${MINER_COINBASE}"]
+      "--miner-coinbase=${MINER_COINBASE}",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -112,7 +114,8 @@ services:
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
       "--privacy-url=http://orion1:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -140,7 +143,8 @@ services:
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
       "--privacy-url=http://orion2:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -168,7 +172,8 @@ services:
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
       "--privacy-url=http://orion3:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml

--- a/docker-compose_elk_privacy_poa.yml
+++ b/docker-compose_elk_privacy_poa.yml
@@ -63,7 +63,8 @@ services:
       "--node-private-key-file=/opt/besu/keys/key",
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
-      "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}" ]
+      "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -157,7 +158,8 @@ services:
       "--min-gas-price=0",
       "--privacy-enabled",
       "--privacy-url=http://orion1:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -188,7 +190,8 @@ services:
       "--min-gas-price=0",
       "--privacy-enabled",
       "--privacy-url=http://orion2:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -219,7 +222,8 @@ services:
       "--min-gas-price=0",
       "--privacy-enabled",
       "--privacy-url=http://orion3:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml

--- a/docker-compose_privacy.yml
+++ b/docker-compose_privacy.yml
@@ -43,7 +43,7 @@ services:
     image: sample-network/besu:${BESU_VERSION}
     environment:
       - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
-    entrypoint: /opt/besu/bootnode_start.sh --config-file=/config/config.toml --network=dev --min-gas-price=0
+    entrypoint: /opt/besu/bootnode_start.sh --config-file=/config/config.toml --network=dev --min-gas-price=0 --privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -56,7 +56,8 @@ services:
       "--config-file=/config/config.toml",
       "--network=dev",
       "--min-gas-price=0",
-      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV" ]
+      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -74,7 +75,8 @@ services:
       "--network=dev",
       "--min-gas-price=0",
       "--miner-enabled=true",
-      "--miner-coinbase=${MINER_COINBASE}"]
+      "--miner-coinbase=${MINER_COINBASE}",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -93,7 +95,8 @@ services:
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
       "--privacy-url=http://orion1:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -118,7 +121,8 @@ services:
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
       "--privacy-url=http://orion2:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -143,7 +147,8 @@ services:
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
       "--privacy-enabled",
       "--privacy-url=http://orion3:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml

--- a/docker-compose_privacy_poa.yml
+++ b/docker-compose_privacy_poa.yml
@@ -50,7 +50,8 @@ services:
       "--node-private-key-file=/opt/besu/keys/key",
       "--min-gas-price=0",
       "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
-      "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}" ]
+      "--rpc-ws-api=EEA,WEB3,ETH,NET,PRIV,${SAMPLE_POA_API-ibft}",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}" ]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -124,7 +125,8 @@ services:
       "--min-gas-price=0",
       "--privacy-enabled",
       "--privacy-url=http://orion1:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -151,7 +153,8 @@ services:
       "--min-gas-price=0",
       "--privacy-enabled",
       "--privacy-url=http://orion2:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml
@@ -178,7 +181,8 @@ services:
       "--min-gas-price=0",
       "--privacy-enabled",
       "--privacy-url=http://orion3:8888",
-      "--privacy-public-key-file=/config/orion/orion.pub"]
+      "--privacy-public-key-file=/config/orion/orion.pub",
+      "--privacy-onchain-groups-enabled=${PRIVACY_ONCHAIN_GROUPS_ENABLED}"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/config.toml:/config/config.toml

--- a/run-privacy.sh
+++ b/run-privacy.sh
@@ -22,10 +22,12 @@ PARAMS=""
 displayUsage()
 {
   echo "This script creates and start a local private Besu network using Docker."
-  echo "You can select the consensus mechanism to use.\n"
+  echo -e "You can select the consensus mechanism and privacy group mode to use.\n"
   echo "Usage: ${me} [OPTIONS]"
   echo "    -c <ibft2|clique|ethash> : the consensus mechanism that you want to run
                                        on your network, default is ethash"
+  echo "    -p <offchain|onchain>    : the privacy group mode that you want to run
+                                       on your network, default is offchain"
   echo "    -e                       : setup ELK with the network."
   exit 0
 }
@@ -41,7 +43,7 @@ clique='clique' # value to use for clique option
 
 composeFile="docker-compose_privacy"
 
-while getopts "hec:" o; do
+while getopts "hec:p:" o; do
   case "${o}" in
     h)
       displayUsage
@@ -57,7 +59,7 @@ while getopts "hec:" o; do
         ethash)
           ;;
         *)
-          echo "Error: Unsupported consensus value." >&2
+          echo -e "Error: Unsupported consensus value.\n" >&2
           displayUsage
       esac
       ;;
@@ -65,6 +67,20 @@ while getopts "hec:" o; do
       elk_compose="${composeFile/docker-compose/docker-compose_elk}"
       composeFile="$elk_compose"
       ;;
+    p)
+      privmode=${OPTARG}
+      case "${privmode}" in
+        onchain)
+          export PRIVACY_ONCHAIN_GROUPS_ENABLED=true
+          ;;
+        offchain)
+          export PRIVACY_ONCHAIN_GROUPS_ENABLED=false
+          ;;
+        *)
+          echo -e "Error: Unsupported privacy group mode (must be offchain or onchain).\n" >&2
+          displayUsage
+        esac
+        ;;
     *)
       displayUsage
     ;;


### PR DESCRIPTION
This PR adds support for onchain privacy groups.
The flag `-p` can be used to specify `offchain` (default) or `onchain` privacy group mode.